### PR TITLE
Fix logger in SdJournal, add optional filters and Docker journald tags

### DIFF
--- a/cloud-watch/cloudwatch_journal_repeater.go
+++ b/cloud-watch/cloudwatch_journal_repeater.go
@@ -101,6 +101,9 @@ func (repeater *CloudWatchJournalRepeater) WriteBatch(records []*Record) error {
 		}
 
 		if len(describeOutput.LogStreams) > 0 {
+			if describeOutput.LogStreams[0].UploadSequenceToken == nil {
+				return nil
+			}
 			repeater.nextSequenceToken =
 				*describeOutput.LogStreams[0].UploadSequenceToken
 

--- a/cloud-watch/config.go
+++ b/cloud-watch/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Tail                 bool     `hcl:"tail"`
 	Rewind               int      `hcl:"rewind"`
 	Local                bool     `hcl:"local"`
+	Filters              []string `hcl:"filters"`
 	AllowedFields        []string `hcl:"fields"`
 	OmitFields           []string `hcl:"omit_fields"`
 	logPriority          int

--- a/cloud-watch/creators.go
+++ b/cloud-watch/creators.go
@@ -30,7 +30,7 @@ func CreateRepeater(config *Config, logger lg.Logger) JournalRepeater {
 	var err error
 
 	if !config.MockCloudWatch {
-		logger.Info("Creating repeater that is conneting to AWS cloud watch")
+		logger.Info("Creating repeater that is connecting to AWS cloud watch")
 		session := NewAWSSession(config)
 		repeater, err = NewCloudWatchJournalRepeater(session, nil, config)
 

--- a/cloud-watch/journal_linux.go
+++ b/cloud-watch/journal_linux.go
@@ -4,17 +4,18 @@ import (
 	"github.com/coreos/go-systemd/sdjournal"
 	"strconv"
 	"time"
+	lg "github.com/advantageous/go-logback/logging"
 )
 
 type SdJournal struct {
 	journal *sdjournal.Journal
-	logger  *Logger
+	logger  lg.Logger
 	debug   bool
 }
 
 func NewJournal(config *Config) (Journal, error) {
 
-	logger := NewSimpleLogger("journal", config)
+	logger := lg.NewSimpleLogger("journal")
 
 	var debug bool
 
@@ -30,7 +31,7 @@ func NewJournal(config *Config) (Journal, error) {
 			journal, logger, debug,
 		}, err
 	} else {
-		logger.Info.Printf("using journal dir: %s", config.JournalDir)
+		logger.Infof("using journal dir: %s", config.JournalDir)
 		journal, err := sdjournal.NewJournalFromDir(config.JournalDir)
 
 		return &SdJournal{
@@ -61,7 +62,7 @@ func (journal *SdJournal) Close() error {
 func (journal *SdJournal) Next() (uint64, error) {
 	loc, err := journal.journal.Next()
 	if journal.debug {
-		journal.logger.Info.Printf("NEXT location %d %v", loc, err)
+		journal.logger.Infof("NEXT location %d %v", loc, err)
 	}
 
 	return loc, err

--- a/cloud-watch/journal_linux.go
+++ b/cloud-watch/journal_linux.go
@@ -52,6 +52,12 @@ func (journal *SdJournal) AddLogFilters(config *Config) {
 		}
 		journal.journal.AddDisjunction()
 	}
+	// Add other Filters
+	if config.Filters != nil && len(config.Filters) > 0 {
+		for _, filter := range config.Filters {
+			journal.journal.AddMatch(filter)
+		}
+	}
 }
 
 func (journal *SdJournal) Close() error {

--- a/cloud-watch/record.go
+++ b/cloud-watch/record.go
@@ -32,31 +32,35 @@ var PriorityJsonMap = map[Priority][]byte{
 }
 
 type Record struct {
-	InstanceId  string   `json:"instanceId,omitempty"`
-	TimeUsec    int64    `json:"-" journald:"__REALTIME_TIMESTAMP"`
-	PID         int      `json:"pid,omitempty" journald:"_PID"`
-	UID         int      `json:"uid,omitempty" journald:"_UID"`
-	GID         int      `json:"gid,omitempty" journald:"_GID"`
-	Command     string   `json:"cmdName,omitempty" journald:"_COMM"`
-	Executable  string   `json:"exe,omitempty" journald:"_EXE"`
-	CommandLine string   `json:"cmdLine,omitempty" journald:"_CMDLINE"`
-	SystemdUnit string   `json:"systemdUnit,omitempty" journald:"_SYSTEMD_UNIT"`
-	BootId      string   `json:"bootId,omitempty" journald:"_BOOT_ID"`
-	MachineId   string   `json:"machineId,omitempty" journald:"_MACHINE_ID"`
-	Hostname    string   `json:"hostname,omitempty" journald:"_HOSTNAME"`
-	Transport   string   `json:"transport,omitempty" journald:"_TRANSPORT"`
-	Priority    Priority `json:"priority" journald:"PRIORITY"`
-	Message     string   `json:"message" journald:"MESSAGE"`
-	MessageId   string   `json:"messageId,omitempty" journald:"MESSAGE_ID"`
-	Errno       int      `json:"machineId,omitempty" journald:"ERRNO"`
-	SeqId       int64    `json:"seq,omitempty" `
-	Facility    int      `json:"syslogFacility,omitempty" journald:"SYSLOG_FACILITY"`
-	Identifier  string   `json:"syslogIdent,omitempty" journald:"SYSLOG_IDENTIFIER"`
-	SysPID      int      `json:"syslogPid,omitempty" journald:"SYSLOG_PID"`
-	Device      string   `json:"kernelDevice,omitempty" journald:"_KERNEL_DEVICE"`
-	Subsystem   string   `json:"kernelSubsystem,omitempty" journald:"_KERNEL_SUBSYSTEM"`
-	SysName     string   `json:"kernelSysName,omitempty" journald:"_UDEV_SYSNAME"`
-	DevNode     string   `json:"kernelDevNode,omitempty" journald:"_UDEV_DEVNODE"`
+	InstanceId      string   `json:"instanceId,omitempty"`
+	TimeUsec        int64    `json:"-" journald:"__REALTIME_TIMESTAMP"`
+	PID             int      `json:"pid,omitempty" journald:"_PID"`
+	UID             int      `json:"uid,omitempty" journald:"_UID"`
+	GID             int      `json:"gid,omitempty" journald:"_GID"`
+	Command         string   `json:"cmdName,omitempty" journald:"_COMM"`
+	Executable      string   `json:"exe,omitempty" journald:"_EXE"`
+	CommandLine     string   `json:"cmdLine,omitempty" journald:"_CMDLINE"`
+	SystemdUnit     string   `json:"systemdUnit,omitempty" journald:"_SYSTEMD_UNIT"`
+	BootId          string   `json:"bootId,omitempty" journald:"_BOOT_ID"`
+	MachineId       string   `json:"machineId,omitempty" journald:"_MACHINE_ID"`
+	Hostname        string   `json:"hostname,omitempty" journald:"_HOSTNAME"`
+	Transport       string   `json:"transport,omitempty" journald:"_TRANSPORT"`
+	Priority        Priority `json:"priority" journald:"PRIORITY"`
+	Message         string   `json:"message" journald:"MESSAGE"`
+	MessageId       string   `json:"messageId,omitempty" journald:"MESSAGE_ID"`
+	Errno           int      `json:"machineId,omitempty" journald:"ERRNO"`
+	SeqId           int64    `json:"seq,omitempty" `
+	Facility        int      `json:"syslogFacility,omitempty" journald:"SYSLOG_FACILITY"`
+	Identifier      string   `json:"syslogIdent,omitempty" journald:"SYSLOG_IDENTIFIER"`
+	SysPID          int      `json:"syslogPid,omitempty" journald:"SYSLOG_PID"`
+	Device          string   `json:"kernelDevice,omitempty" journald:"_KERNEL_DEVICE"`
+	Subsystem       string   `json:"kernelSubsystem,omitempty" journald:"_KERNEL_SUBSYSTEM"`
+	SysName         string   `json:"kernelSysName,omitempty" journald:"_UDEV_SYSNAME"`
+	DevNode         string   `json:"kernelDevNode,omitempty" journald:"_UDEV_DEVNODE"`
+	ContainerId     string   `json:"containerId,omitempty" journald:"CONTAINER_ID"`
+	ContainerIdFull string   `json:"containerIdFull,omitempty" journald:"CONTAINER_ID_FULL"`
+	ContainerName   string   `json:"containerName,omitempty" journald:"CONTAINER_NAME"`
+	ContainerTag    string   `json:"containerTag,omitempty" journald:"CONTAINER_TAG"`
 }
 
 func NewRecord(journal Journal, logger lg.Logger, config *Config) (*Record, error) {

--- a/cloud-watch/workers.go
+++ b/cloud-watch/workers.go
@@ -89,7 +89,7 @@ func NewRunnerInternal(journal Journal, repeater JournalRepeater, logger lg.Logg
 				r.sendBatch()
 				now := time.Now().Unix()
 				if now-r.lastMetricTime > 120 {
-					now = r.lastMetricTime
+					r.lastMetricTime = now
 					r.logger.Infof("Systemd CloudWatch: batches sent %d, idleCount %d,  emptyCount %d",
 						r.batchCounter, r.idleCounter, r.emptyCounter)
 				}


### PR DESCRIPTION
Some fixes and additional features:

-    Fix: SdJournal was still using the old logger, which has been removed.
-    Fix: Check for nil-pointer in WriteBatch() before dereferencing it.
-    Fix: IdleFunc() listener was logging too much because lastMetricTime was never updated.
-    The user can now specify (optional) journald filters in the configuration file.
-    Docker's journald log driver stores additional metadata tags (for example: CONTAINER_ID) with each log message. These have been added to the Record struct.
